### PR TITLE
Test PKGBUILD via Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,8 @@
+sudo: required
+
+services:
+  - docker
+
+script:
+  - docker pull base/archlinux
+  - docker run -v $TRAVIS_BUILD_DIR:/pkg base/archlinux /bin/sh /pkg/travis.sh

--- a/travis.sh
+++ b/travis.sh
@@ -1,0 +1,24 @@
+#!/bin/sh
+
+set -e
+
+cd /pkg
+
+# makepkg cannot (and should not) be run as root:
+useradd -m notroot
+
+# Allow notroot to run stuff as root (to install dependencies):
+mkdir /etc/sudoers.d
+echo "notroot ALL=(ALL) NOPASSWD: ALL" > /etc/sudoers.d/notroot
+chmod 400 /etc/sudoers.d/notroot
+
+# Also, make sure we can do the actual building
+chmod 777 /pkg
+
+# Generally, refreshing without sync'ing is discouraged, but we've a clean
+# environment here.
+pacman -Sy --noconfirm base-devel
+
+# Let's get to it!
+sudo -u notroot gpg --recv-keys 5FAF0A6EE7371805
+sudo -u notroot makepkg -fs --noconfirm


### PR DESCRIPTION
This PR tests any commits via Travis CI. It also lets you test the `PKGBUILD` on non-arch systems (since it only relies on docker).

I'll rewrite into a `Dockerfile` when a have a bit more time (I'd very much like to make this package agnostic and reusable), but this should work perfectly for now anyway.

Before merging this PR, please enable CI [here](https://travis-ci.org/profile/neomutt). Then close and reopen this PR to trigger a Travis run.